### PR TITLE
Remove Tuinity

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,9 +210,8 @@ _Minecraft server software._
 
 - [Nukkit](https://github.com/CloudburstMC/Nukkit) - Server software for Minecraft: Bedrock Edition.
 - [Paper](https://github.com/papermc/paper) - High performance Spigot fork that aims to fix gameplay and mechanics inconsistencies.
-- [Purpur](https://github.com/pl3xgaming/Purpur) - Purpur is a fork of Paper and Tuinity with the goal of providing new and interesting configuration options, which allow for creating a unique gameplay experience not seen anywhere else.
+- [Purpur](https://github.com/pl3xgaming/Purpur) - Purpur is a drop-in replacement for Paper servers designed for configurability, new fun and exciting gameplay features, and high performance built on top of Airplane.
 - [Sponge](https://github.com/SpongePowered/Sponge) - A community-driven open source Minecraft: Java Edition modding platform.
-- [Tuinity](https://github.com/spottedleaf/tuinity) - Fork of Paper aimed at improving server performance at high playercounts.
 
 ## Tools
 _Miscellaneous tools._


### PR DESCRIPTION
This is because Tuinity and Paper have merged.
Additionally, the description for Purpr has been updated.

Closes #32