### PR TITLE
Remove Waterfall.

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,8 +206,6 @@ _Minecraft server proxy software._
 
 - [Geyser](https://github.com/GeyserMC/Geyser) - A bridge/proxy allowing you to connect to Minecraft: Java Edition servers with Minecraft: Bedrock edition.
 - [Velocity](https://github.com/velocitypowered/velocity) - A Minecraft server proxy with unparalleled server support, scalability, and flexibility.
-- [Waterfall](https://github.com/papermc/waterfall) - BungeeCord fork that aims to improve performance and stability.
-
 ## Server Software
 _Minecraft server software._
 


### PR DESCRIPTION
Waterfall is [EoL](https://forums.papermc.io/threads/announcing-the-end-of-life-of-waterfall.1088/) and shouldn't be reccomended.