### PR TITLE
Removed wiki.vg

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,9 +196,6 @@ _Resources for Minecraft performance tuning._
 - [Krusic22's Flags](https://krusic22.com/2020/03/25/higher-performance-crafting-using-jdk11-and-zgc/) - Optimized JDK11+ & ZGC flags for Minecraft servers.
 - [StartMC](https://startmc.sh/) - Aikars flags script generator.
 
-## Protocol
-- [wiki.vg](https://wiki.vg) - Wiki.vg has documented the whole minecraft protocol for java and bedrock edition.
-
 # Software
 
 ## Proxy Software


### PR DESCRIPTION
Two years ago I was the one to add wiki.vg as an amazing resource on the minecraft protocol. As the "hoster" decided to sunset it, I am now the one to remove it from this list.
As of now it has been merged into the minecraft wiki. Maybe it is worth to consider adding it to this list.